### PR TITLE
Delegate paste if not link

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -28,7 +28,7 @@ export default class AutoLinkTitle extends Plugin {
     this.addCommand({
       id: "paste-url-with-title",
       name: "Paste and auto populate URL titles",
-      callback: () => this.pasteUrlWithTitle(),
+      checkCallback: () => this.pasteUrlWithTitle(),
       hotkeys: [
         {
           modifiers: ["Mod"],
@@ -64,7 +64,7 @@ export default class AutoLinkTitle extends Plugin {
     }
   }
 
-  pasteUrlWithTitle(): Boolean {
+  pasteUrlWithTitle(): boolean {
     let editor = this.getEditor();
     let clipboardText = clipboard.readText("clipboard");
 

--- a/main.ts
+++ b/main.ts
@@ -31,8 +31,8 @@ export default class AutoLinkTitle extends Plugin {
       callback: () => this.pasteUrlWithTitle(),
       hotkeys: [
         {
-          modifiers: ["Mod", "Shift"],
-          key: "b",
+          modifiers: ["Mod"],
+          key: "v",
         },
       ],
     });
@@ -64,22 +64,22 @@ export default class AutoLinkTitle extends Plugin {
     }
   }
 
-  pasteUrlWithTitle(): void {
+  pasteUrlWithTitle(): Boolean {
     let editor = this.getEditor();
     let clipboardText = clipboard.readText("clipboard");
 
-    if (!clipboardText) return;
+    if (!clipboardText) return false;
 
     // If its not a URL, simply paste the text
     // If it looks like we're pasting the url into a markdown link already, don't fetch title
     // as the user has already probably put a meaningful title, also it would lead to the title 
     // being inside the link
     if (!this.isUrl(clipboardText) || this.isMarkdownLinkAlready()) {
-      editor.replaceSelection(clipboardText);
-      return;
+      return false;
     }
 
     this.convertUrlToTitledLink(clipboardText);
+    return true;
   }
 
   convertUrlToTitledLink(text: string): void {

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,5 @@
 	"description": "This plugin automatically fetches the titles of links from the web",
 	"author": "Matt Furden",
 	"authorUrl": "https://github.com/zolrath",
-	"isDesktopOnly": false
+	"isDesktopOnly": true
 }


### PR DESCRIPTION
Allows overriding `mod-v` while still delegating back to the original