### PR TITLE
Add setting to not replace selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ package-lock.json
 main.js
 *.js.map
 .DS_Store
+
+data.json

--- a/settings.ts
+++ b/settings.ts
@@ -4,6 +4,7 @@ export interface AutoLinkTitleSettings {
   linkRegex: RegExp;
   linkLineRegex: RegExp;
   imageRegex: RegExp;
+  shouldReplaceSelection: boolean;
 }
 
 export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
@@ -11,5 +12,6 @@ export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
   lineRegex: /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/ig,
   linkRegex: /^\[([^\[\]]*)\]\((https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\)$/i,
   linkLineRegex: /\[([^\[\]]*)\]\((https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\)/ig,
-  imageRegex: /\.(gif|jpe?g|tiff?|png|webp|bmp|tga|psd|ai)/i
+  imageRegex: /\.(gif|jpe?g|tiff?|png|webp|bmp|tga|psd|ai)/i,
+  shouldReplaceSelection: true
 }


### PR DESCRIPTION
Addresses #10

Adds a setting tab for whether to replace a selection. Defaults to true so current functionality is unchanged. If a user sets this to false, it will simply paste the URL over the selection without fetching the title.

This adds compatibility between this plugin and [Paste URL Into Selection](https://github.com/denolehov/obsidian-url-into-selection)