### PR TITLE
Refactor to use async/await

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -89,36 +89,34 @@ export default class AutoLinkTitle extends Plugin {
     return;
   }
 
-  convertUrlToTitledLink(editor: Editor, text: string): void {
+  async convertUrlToTitledLink(editor: Editor, url: string): Promise<void> {
     // Generate a unique id for find/replace operations for the title.
-    let pasteId = `Fetching Title#${this.createBlockHash()}`;
+    const pasteId = `Fetching Title#${this.createBlockHash()}`;
 
     // Instantly paste so you don't wonder if paste is broken
-    editor.replaceSelection(`[${pasteId}](${text})`);
+    editor.replaceSelection(`[${pasteId}](${url})`);
 
     // Fetch title from site, replace Fetching Title with actual title
-    this.fetchUrlTitle(text).then((title) => {
-      let text = editor.getValue();
+    const title = await this.fetchUrlTitle(url)
 
-      let start = text.indexOf(pasteId);
-      let end = start + pasteId.length;
-      let startPos = EditorExtensions.getEditorPositionFromIndex(text, start);
-      let endPos = EditorExtensions.getEditorPositionFromIndex(text, end);
+    const text = editor.getValue();
 
-      editor.replaceRange(title, startPos, endPos);
-    });
+    const start = text.indexOf(pasteId);
+    const end = start + pasteId.length;
+    const startPos = EditorExtensions.getEditorPositionFromIndex(text, start);
+    const endPos = EditorExtensions.getEditorPositionFromIndex(text, end);
+
+    editor.replaceRange(title, startPos, endPos);
   }
 
-  fetchUrlTitle(text: string): Promise<string> {
-    return getPageTitle(text).then(title => {
-      if (title == null || title == "") {
-          return "Title Unknown";
-      }
+  async fetchUrlTitle(text: string): Promise<string> {
+    try {
+      const title = await getPageTitle(text);
       return title.trim();
-    }).catch((error) => {
+    } catch (error) {
       // console.error(error)
       return "Site Unreachable"
-    });
+    }
   }
 
   private getEditor(): Editor {

--- a/scraper.ts
+++ b/scraper.ts
@@ -1,71 +1,92 @@
 const electronPkg = require("electron");
 
-export default function getPageTitle(url: string): Promise<string> {
+function blank(text: string): boolean {
+  return text === undefined || text === null || text === '';
+}
+
+function notBlank(text: string): boolean {
+  return !blank(text);
+}
+
+// async wrapper to load a url and settle on load finish or fail
+async function load(window: any, url: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    window.webContents.on("did-finish-load", (event: any) => resolve(event));
+    window.webContents.on("did-fail-load", (event: any) => reject(event));
+    window.loadURL(url);
+  });
+}
+
+async function electronGetPageTitle(url: string): Promise<string> {
+  const { remote } = electronPkg;
+  const { BrowserWindow } = remote;
+
+  try {
+    const window = new BrowserWindow({
+      width: 1000,
+      height: 600,
+      webPreferences: {
+        webSecurity: false,
+        nodeIntegration: true,
+        images: false,
+      },
+      show: false,
+    });
+
+    await load(window, url);
+
+    try {
+      const title = window.webContents.getTitle();
+      window.destroy();
+
+      if (notBlank(title)) {
+        return title;
+      } else {
+        return "Title Unknown";
+      }
+    } catch (ex) {
+      return "Title Unknown";
+    }
+  } catch (ex) {
+    console.error(ex);
+    return "Site Unreachable";
+  }
+}
+
+async function nonElectronGetPageTitle(url: string): Promise<string> {
+  // if we're on mobile use a CORS proxy; because of CORS you can't fetch the site directly
+  const corsed = `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`;
+
+  try {
+    const response = await fetch(corsed);
+    const html = await response.text();
+
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const title = doc.querySelectorAll("title")[0];
+
+    if (title == null || blank(title.innerText)) {
+      // If site is javascript based and has a no-title attribute when unloaded, use it.
+      var noTitle = title.getAttr("no-title");
+      if (notBlank(noTitle)) {
+        return noTitle;
+      }
+
+      // Otherwise if the site has no title/requires javascript simply return Title Unknown
+      return "Title Unknown";
+    }
+
+    return title.innerText;
+  } catch (ex) {
+    console.error(ex);
+    return "Site Unreachable";
+  }
+}
+
+export default async function getPageTitle(url: string): Promise<string> {
   // If we're on Desktop use the Electron scraper
   if (electronPkg != null) {
-    const { remote } = electronPkg;
-    const { BrowserWindow } = remote;
-    return new Promise<string>((resolve) => {
-      try {
-        const window = new BrowserWindow({
-          width: 1000,
-          height: 600,
-          webPreferences: {
-            webSecurity: false,
-            nodeIntegration: true,
-            images: false,
-          },
-          show: false,
-        });
-
-        window.webContents.on("did-finish-load", async () => {
-          try {
-            const title = window.webContents.getTitle();
-            window.destroy();
-            if (title != null && title != '') {
-              resolve(title);
-            } else {
-              resolve("Title Unknown");
-            }
-          } catch (ex) {
-            resolve("Title Unknown");
-          }
-        });
-
-        window.loadURL(url);
-      } catch (ex) {
-        resolve("Site Unreachable");
-      }
-    });
-    // Otherwise if we're on mobile use a CORS proxy
+    return electronGetPageTitle(url);
   } else {
-    return new Promise<string>((resolve) => {
-      // console.log(`Fetching ${text} for title`);
-      //Because of CORS you can't fetch the site directly
-      var corsed = `https://api.allorigins.win/get?url=${encodeURIComponent(
-        url
-      )}`;
-      fetch(corsed)
-        .then((response) => {
-          return response.text();
-        })
-        .then((html) => {
-          const doc = new DOMParser().parseFromString(html, "text/html");
-          const title = doc.querySelectorAll("title")[0];
-          if (title == null || title.innerText.length == 0) {
-            // If site is javascript based and has a no-title attribute when unloaded, use it.
-            var noTitle = title.getAttr("no-title");
-            if (noTitle != null) return noTitle;
-
-            // Otherwise if the site has no title/requires javascript simply return Title Unknown
-            return resolve("Title Unknown");
-          }
-          return resolve(title.innerText);
-        })
-        .catch((error) => {
-          console.error(error);
-          return resolve("Site Unreachable");
-        });
-    });
+    return nonElectronGetPageTitle(url);
   }
 }


### PR DESCRIPTION
Refactor main.ts and scraper.ts to use async/await in main logic instead of .then() or event callbacks.

Depends on https://github.com/zolrath/obsidian-auto-link-title/pull/28