### PR TITLE
Add ability to rebind auto link title paste

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -73,13 +73,13 @@ export default class AutoLinkTitle extends Plugin {
     }
   }
 
-  // Simulate standard paste but using editor.replaceRange with clipboard text since we can't seem to dispatch a paste event.
+  // Simulate standard paste but using editor.replaceSelection with clipboard text since we can't seem to dispatch a paste event.
   async manualPasteUrlWithTitle(): Promise<void> {
     let editor = this.getEditor();
 
     // Only attempt fetch if online
     if (!navigator.onLine) {
-      editor.replaceRange(clipboardText, editor.getCursor());
+      editor.replaceSelection(clipboardText);
       return;
     }
 

--- a/main.ts
+++ b/main.ts
@@ -1,13 +1,10 @@
 import { EditorExtensions } from "editor-enhancements";
+import { Plugin, MarkdownView, Editor } from "obsidian";
 import {
-  Plugin,
-  MarkdownView,
-  Editor,
-  PluginSettingTab,
-  App,
-  Setting,
-} from "obsidian";
-import { AutoLinkTitleSettings, DEFAULT_SETTINGS } from "./settings";
+  AutoLinkTitleSettings,
+  AutoLinkTitleSettingTab,
+  DEFAULT_SETTINGS,
+} from "./settings";
 import { CheckIf } from "checkif";
 import getPageTitle from "scraper";
 
@@ -25,6 +22,22 @@ export default class AutoLinkTitle extends Plugin {
 
     // Listen to paste event
     this.pasteFunction = this.pasteUrlWithTitle.bind(this);
+
+    this.addCommand({
+      id: "auto-link-title-paste",
+      name: "Paste URL and auto fetch Title",
+      callback: () => {
+        console.log("did the thing");
+        this.manualPasteUrlWithTitle();
+      },
+      hotkeys: [
+        {
+          modifiers: ["Mod", "Shift"],
+          key: "v",
+        },
+      ],
+    });
+
     this.app.workspace.containerEl.addEventListener(
       "paste",
       this.pasteFunction,
@@ -66,7 +79,52 @@ export default class AutoLinkTitle extends Plugin {
     }
   }
 
-  pasteUrlWithTitle(clipboard: ClipboardEvent): void {
+  // Simulate standard paste but using editor.replaceRange with clipboard text since we can't seem to dispatch a paste event.
+  async manualPasteUrlWithTitle(): Promise<void> {
+    let editor = this.getEditor();
+
+    // Only attempt fetch if online
+    if (!navigator.onLine) {
+      editor.replaceRange(clipboardText, editor.getCursor());
+      return;
+    }
+
+    var clipboardText = await navigator.clipboard.readText();
+    if (clipboardText == null || clipboardText == "") return;
+
+    // If its not a URL, we return false to allow the default paste handler to take care of it.
+    // Similarly, image urls don't have a meaningful <title> attribute so downloading it
+    // to fetch the title is a waste of bandwidth.
+    if (!CheckIf.isUrl(clipboardText) || CheckIf.isImage(clipboardText)) {
+      editor.replaceRange(clipboardText, editor.getCursor());
+      return;
+    }
+
+    let selectedText = (EditorExtensions.getSelectedText(editor) || "").trim();
+    if (selectedText && !this.settings.shouldReplaceSelection) {
+      // If there is selected text and shouldReplaceSelection is false, do not fetch title
+      editor.replaceRange(clipboardText, editor.getCursor());
+      return;
+    }
+
+    // If it looks like we're pasting the url into a markdown link already, don't fetch title
+    // as the user has already probably put a meaningful title, also it would lead to the title
+    // being inside the link.
+    if (CheckIf.isMarkdownLinkAlready(editor) || CheckIf.isAfterQuote(editor)) {
+      editor.replaceSelection(clipboardText);
+      return;
+    }
+
+    // At this point we're just pasting a link in a normal fashion, fetch its title.
+    this.convertUrlToTitledLink(editor, clipboardText);
+    return;
+  }
+
+  async pasteUrlWithTitle(clipboard: ClipboardEvent): Promise<void> {
+    if (!this.settings.enhanceDefaultPaste) {
+      return;
+    }
+
     // Only attempt fetch if online
     if (!navigator.onLine) return;
 
@@ -177,35 +235,5 @@ export default class AutoLinkTitle extends Plugin {
 
   async saveSettings() {
     await this.saveData(this.settings);
-  }
-}
-
-class AutoLinkTitleSettingTab extends PluginSettingTab {
-  plugin: AutoLinkTitle;
-
-  constructor(app: App, plugin: AutoLinkTitle) {
-    super(app, plugin);
-    this.plugin = plugin;
-  }
-
-  display(): void {
-    let { containerEl } = this;
-
-    containerEl.empty();
-
-    new Setting(containerEl)
-      .setName("Replace Selection")
-      .setDesc(
-        "Whether to replace a text selection with link and fetched title"
-      )
-      .addToggle((val) =>
-        val
-          .setValue(this.plugin.settings.shouldReplaceSelection)
-          .onChange(async (value) => {
-            console.log(value);
-            this.plugin.settings.shouldReplaceSelection = value;
-            await this.plugin.saveSettings();
-          })
-      );
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -25,9 +25,8 @@ export default class AutoLinkTitle extends Plugin {
 
     this.addCommand({
       id: "auto-link-title-paste",
-      name: "Paste URL and auto fetch Title",
+      name: "Paste URL and auto fetch title",
       callback: () => {
-        console.log("did the thing");
         this.manualPasteUrlWithTitle();
       },
       hotkeys: [

--- a/main.ts
+++ b/main.ts
@@ -29,12 +29,7 @@ export default class AutoLinkTitle extends Plugin {
       callback: () => {
         this.manualPasteUrlWithTitle();
       },
-      hotkeys: [
-        {
-          modifiers: ["Mod", "Shift"],
-          key: "v",
-        },
-      ],
+      hotkeys: [],
     });
 
     this.app.workspace.containerEl.addEventListener(

--- a/main.ts
+++ b/main.ts
@@ -95,14 +95,14 @@ export default class AutoLinkTitle extends Plugin {
     // Similarly, image urls don't have a meaningful <title> attribute so downloading it
     // to fetch the title is a waste of bandwidth.
     if (!CheckIf.isUrl(clipboardText) || CheckIf.isImage(clipboardText)) {
-      editor.replaceRange(clipboardText, editor.getCursor());
+      editor.replaceSelection(clipboardText);
       return;
     }
 
     let selectedText = (EditorExtensions.getSelectedText(editor) || "").trim();
     if (selectedText && !this.settings.shouldReplaceSelection) {
       // If there is selected text and shouldReplaceSelection is false, do not fetch title
-      editor.replaceRange(clipboardText, editor.getCursor());
+      editor.replaceSelection(clipboardText);
       return;
     }
 

--- a/scraper.ts
+++ b/scraper.ts
@@ -1,5 +1,5 @@
 const electronPkg = require("electron");
-import { request, RequestParam } from "obsidian";
+import { request } from "obsidian";
 
 function blank(text: string): boolean {
   return text === undefined || text === null || text === "";

--- a/settings.ts
+++ b/settings.ts
@@ -1,3 +1,6 @@
+import AutoLinkTitle from "main";
+import { PluginSettingTab, Setting } from "obsidian";
+
 export interface AutoLinkTitleSettings {
   regex: RegExp;
   lineRegex: RegExp;
@@ -5,13 +8,64 @@ export interface AutoLinkTitleSettings {
   linkLineRegex: RegExp;
   imageRegex: RegExp;
   shouldReplaceSelection: boolean;
+  enhanceDefaultPaste: boolean;
 }
 
 export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
-  regex: /^(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})$/i,
-  lineRegex: /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/ig,
-  linkRegex: /^\[([^\[\]]*)\]\((https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\)$/i,
-  linkLineRegex: /\[([^\[\]]*)\]\((https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\)/ig,
+  regex:
+    /^(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})$/i,
+  lineRegex:
+    /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi,
+  linkRegex:
+    /^\[([^\[\]]*)\]\((https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\)$/i,
+  linkLineRegex:
+    /\[([^\[\]]*)\]\((https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})\)/gi,
   imageRegex: /\.(gif|jpe?g|tiff?|png|webp|bmp|tga|psd|ai)$/i,
-  shouldReplaceSelection: true
+  shouldReplaceSelection: true,
+  enhanceDefaultPaste: true,
+};
+
+export class AutoLinkTitleSettingTab extends PluginSettingTab {
+  plugin: AutoLinkTitle;
+
+  constructor(app: App, plugin: AutoLinkTitle) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    let { containerEl } = this;
+
+    containerEl.empty();
+
+    new Setting(containerEl)
+      .setName("Enhance Default Paste")
+      .setDesc(
+        "Fetch the link title when pasting a link in the editor with the default paste command"
+      )
+      .addToggle((val) =>
+        val
+          .setValue(this.plugin.settings.enhanceDefaultPaste)
+          .onChange(async (value) => {
+            console.log(value);
+            this.plugin.settings.enhanceDefaultPaste = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Replace Selection")
+      .setDesc(
+        "Whether to replace a text selection with link and fetched title"
+      )
+      .addToggle((val) =>
+        val
+          .setValue(this.plugin.settings.shouldReplaceSelection)
+          .onChange(async (value) => {
+            console.log(value);
+            this.plugin.settings.shouldReplaceSelection = value;
+            await this.plugin.saveSettings();
+          })
+      );
+  }
 }

--- a/settings.ts
+++ b/settings.ts
@@ -1,5 +1,5 @@
 import AutoLinkTitle from "main";
-import { PluginSettingTab, Setting } from "obsidian";
+import { App, PluginSettingTab, Setting } from "obsidian";
 
 export interface AutoLinkTitleSettings {
   regex: RegExp;


### PR DESCRIPTION
Adds the ability to disable "Enhance Default Paste" which leaves the standard paste hotkey untouched.

I've also added a hotkey (unbound by default) which will allow users to set up a hotkey of their choosing to trigger the standard Auto Link Title paste behavior.

![image](https://user-images.githubusercontent.com/454563/150235769-3f7a2b55-9f98-47c3-94b5-1f6cde0bb3da.png)

![image](https://user-images.githubusercontent.com/454563/150235751-62aef9e8-b3c8-4ee4-8b7c-4553071ebde6.png)
