### PR TITLE
Mute BrowserWindow audio to prevent sound playing

### DIFF
--- a/scraper.ts
+++ b/scraper.ts
@@ -33,6 +33,7 @@ async function electronGetPageTitle(url: string): Promise<string> {
       },
       show: false,
     });
+    window.webContents.setAudioMuted(true);
 
     await load(window, url);
 


### PR DESCRIPTION
Solves this issue: https://github.com/zolrath/obsidian-auto-link-title/issues/37