### PR TITLE
Add option to use html a tag links instead of markdown

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -162,7 +162,11 @@ export default class AutoLinkTitle extends Plugin {
     const pasteId = `Fetching Title#${this.createBlockHash()}`;
 
     // Instantly paste so you don't wonder if paste is broken
-    editor.replaceSelection(`[${pasteId}](${url})`);
+    if (!this.settings.htmlLink) {
+      editor.replaceSelection(`[${pasteId}](${url})`);
+    } else {
+      editor.replaceSelection(`<a href="${url}">${pasteId}</a>`);
+    }
 
     // Fetch title from site, replace Fetching Title with actual title
     const title = await this.fetchUrlTitle(url);

--- a/settings.ts
+++ b/settings.ts
@@ -9,6 +9,7 @@ export interface AutoLinkTitleSettings {
   imageRegex: RegExp;
   shouldReplaceSelection: boolean;
   enhanceDefaultPaste: boolean;
+  htmlLink: boolean;
 }
 
 export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
@@ -23,6 +24,7 @@ export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
   imageRegex: /\.(gif|jpe?g|tiff?|png|webp|bmp|tga|psd|ai)$/i,
   shouldReplaceSelection: true,
   enhanceDefaultPaste: true,
+  htmlLink: false,
 };
 
 export class AutoLinkTitleSettingTab extends PluginSettingTab {
@@ -49,6 +51,21 @@ export class AutoLinkTitleSettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             console.log(value);
             this.plugin.settings.enhanceDefaultPaste = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Use HTML Links")
+      .setDesc(
+        "Use an html <a> tag instead of markdown style []() links"
+      )
+      .addToggle((val) =>
+        val
+          .setValue(this.plugin.settings.htmlLink)
+          .onChange(async (value) => {
+            console.log(value);
+            this.plugin.settings.htmlLink = value;
             await this.plugin.saveSettings();
           })
       );


### PR DESCRIPTION
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/1986068/182462505-3e33c78b-1d16-4cc2-9003-7f7ef71b245a.png">
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/1986068/182462649-ac2270d3-e22c-46f1-be77-7754b4defadb.png">
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/1986068/182462594-9ca99137-1aa8-466f-b744-312e303876cd.png">
<img width="1069" alt="image" src="https://user-images.githubusercontent.com/1986068/182462605-3651e96e-66ad-4c3a-882d-c1b0fb642486.png">
