### PR TITLE
Prevent sounds from autoplaying in the background

### DIFF
--- a/scraper.ts
+++ b/scraper.ts
@@ -33,6 +33,7 @@ async function electronGetPageTitle(url: string): Promise<string> {
       },
       show: false,
     });
+    window.webContents.setAudioMuted(true);
 
     await load(window, url);
 


### PR DESCRIPTION
Some websites (e.g. YouTube) have autoplaying content. When a link to one of these is pasted, and they get opened in the background, their sound can be heard for a brief moment. This PR mutes the background window, so no sound can be heard.