### PR TITLE
Add ability to blacklist websites, closes #51

### DIFF
--- a/settings.ts
+++ b/settings.ts
@@ -9,6 +9,7 @@ export interface AutoLinkTitleSettings {
   imageRegex: RegExp;
   shouldReplaceSelection: boolean;
   enhanceDefaultPaste: boolean;
+  websiteBlacklist: string;
 }
 
 export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
@@ -23,6 +24,7 @@ export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
   imageRegex: /\.(gif|jpe?g|tiff?|png|webp|bmp|tga|psd|ai)$/i,
   shouldReplaceSelection: true,
   enhanceDefaultPaste: true,
+  websiteBlacklist: "",
 };
 
 export class AutoLinkTitleSettingTab extends PluginSettingTab {
@@ -64,6 +66,21 @@ export class AutoLinkTitleSettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             console.log(value);
             this.plugin.settings.shouldReplaceSelection = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Website Blacklist")
+      .setDesc(
+        "List of strings (comma separated) that disable autocompleting website titles. Can be URLs or arbitrary text."
+      )
+      .addTextArea((val) =>
+        val
+          .setValue(this.plugin.settings.websiteBlacklist)
+          .setPlaceholder("localhost, tiktok.com")
+          .onChange(async (value) => {
+            this.plugin.settings.websiteBlacklist = value;
             await this.plugin.saveSettings();
           })
       );


### PR DESCRIPTION
Closes #51, currently doesn't restrict blacklist to the domain to allow certain terms to prevent crawling.