### PR TITLE
Add normal paste hotkey (Mod + Shift + V)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -33,6 +33,18 @@ export default class AutoLinkTitle extends Plugin {
       hotkeys: [],
     });
 
+    this.addCommand({
+      id: "auto-link-title-normal-paste",
+      name: "Normal paste (no fetching behavior)",
+      editorCallback: (editor) => this.normalPaste(editor),
+      hotkeys: [
+        {
+          modifiers: ["Mod", "Shift"],
+          key: "v",
+        },
+      ],
+    });
+
     this.registerEvent(
       this.app.workspace.on("editor-paste", this.pasteFunction)
     );
@@ -67,6 +79,14 @@ export default class AutoLinkTitle extends Plugin {
       var link = this.getUrlFromLink(selectedText);
       this.convertUrlToTitledLink(editor, link);
     }
+  }
+
+  async normalPaste(editor: Editor): Promise<void> {
+
+    let clipboardText = await navigator.clipboard.readText();
+    if (clipboardText === null || clipboardText === "") return;
+
+    editor.replaceSelection(clipboardText);
   }
 
   // Simulate standard paste but using editor.replaceSelection with clipboard text since we can't seem to dispatch a paste event.


### PR DESCRIPTION
I tried what rrherr suggested in #39 but it didn't work: `evt.clipboardData.types` was empty no matter what...
So I looked in all the global objects accessible in the plugin but none of them gave any information about the shift key. And when I was about to give up, I thought of the obvious solution: A new hotkey that simply pastes without doing any fancy stuff. It's a dirty workaround but it does the job perfectly.
And it makes it usable on mobile by assigning it to an icon in the toolbar (though it's useless for the moment since the toolbar Paste command does not trigger this plugin either)

Ps: I've just noticed chrisgrieser already suggested that here (https://github.com/zolrath/obsidian-auto-link-title/issues/21#issuecomment-1001016599)