### PR TITLE
fix: escape "[" and "]" in title

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -210,8 +210,8 @@ export default class AutoLinkTitle extends Plugin {
   }
 
   escapeMarkdown(text: string): string {
-    var unescaped = text.replace(/\\(\*|_|`|~|\\)/g, '$1'); // unescape any "backslashed" character
-    var escaped = unescaped.replace(/(\*|_|`|~|\\)/g, '\\$1'); // escape *, _, `, ~, \
+    var unescaped = text.replace(/\\(\*|_|`|~|\\|\[|\])/g, '$1'); // unescape any "backslashed" character
+    var escaped = unescaped.replace(/(\*|_|`|~|\\|\[|\])/g, '\\$1'); // escape *, _, `, ~, \, [, ]
     return escaped;
   }
 


### PR DESCRIPTION
Some websites' title contains `[` and `]`, which could cause some trouble.

e.g. https://www.vidarholen.net/contents/blog/?p=1035

BTW I am slightly confused about why we need to unescape the title first.