### PR TITLE
improve: enable an extra waiting time before get title

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -217,7 +217,7 @@ export default class AutoLinkTitle extends Plugin {
 
   async fetchUrlTitle(url: string): Promise<string> {
     try {
-      const title = await getPageTitle(url);
+      const title = await getPageTitle(url, this.settings.extraWaitingTime);
       return title.replace(/(\r\n|\n|\r)/gm, "").trim();
     } catch (error) {
       // console.error(error)

--- a/scraper.ts
+++ b/scraper.ts
@@ -10,15 +10,15 @@ function notBlank(text: string): boolean {
 }
 
 // async wrapper to load a url and settle on load finish or fail
-async function load(window: any, url: string): Promise<void> {
+async function load(window: any, url: string, extraWaitingTime: number): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    window.webContents.on("did-finish-load", (event: any) => resolve(event));
+    window.webContents.on("did-finish-load", (event: any) => setTimeout(_ => resolve(event), extraWaitingTime));
     window.webContents.on("did-fail-load", (event: any) => reject(event));
     window.loadURL(url);
   });
 }
 
-async function electronGetPageTitle(url: string): Promise<string> {
+async function electronGetPageTitle(url: string, extraWaitingTime: number): Promise<string> {
   const { remote } = electronPkg;
   const { BrowserWindow } = remote;
 
@@ -35,7 +35,7 @@ async function electronGetPageTitle(url: string): Promise<string> {
     });
     window.webContents.setAudioMuted(true);
 
-    await load(window, url);
+    await load(window, url, extraWaitingTime);
 
     try {
       const title = window.webContents.getTitle();
@@ -112,7 +112,7 @@ async function tryGetFileType(url: string) {
   }
 }
 
-export default async function getPageTitle(url: string): Promise<string> {
+export default async function getPageTitle(url: string, extraWaitingTime: number): Promise<string> {
   // If we're on Desktop use the Electron scraper
   if (!(url.startsWith("http") || url.startsWith("https"))) {
     url = "https://" + url;
@@ -126,7 +126,7 @@ export default async function getPageTitle(url: string): Promise<string> {
   }
 
   if (electronPkg != null) {
-    return electronGetPageTitle(url);
+    return electronGetPageTitle(url, extraWaitingTime);
   } else {
     return nonElectronGetPageTitle(url);
   }

--- a/settings.ts
+++ b/settings.ts
@@ -10,6 +10,7 @@ export interface AutoLinkTitleSettings {
   shouldReplaceSelection: boolean;
   enhanceDefaultPaste: boolean;
   websiteBlacklist: string;
+  extraWaitingTime: number;
 }
 
 export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
@@ -25,6 +26,7 @@ export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
   shouldReplaceSelection: true,
   enhanceDefaultPaste: true,
   websiteBlacklist: "",
+  extraWaitingTime: 1000
 };
 
 export class AutoLinkTitleSettingTab extends PluginSettingTab {
@@ -81,6 +83,20 @@ export class AutoLinkTitleSettingTab extends PluginSettingTab {
           .setPlaceholder("localhost, tiktok.com")
           .onChange(async (value) => {
             this.plugin.settings.websiteBlacklist = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Extra Waiting Time")
+      .setDesc("Extra time to wait for the page to update the title. Increase this if you're getting a lot of URL or 'Site Unreachable' titles.")
+      .addText((val) =>
+        val
+          .setValue(this.plugin.settings.extraWaitingTime?.toString())
+          .setPlaceholder(DEFAULT_SETTINGS.extraWaitingTime.toString())
+          .onChange(async (value) => {
+            const valueAsNumber = parseInt(value);
+            this.plugin.settings.extraWaitingTime = isNaN(valueAsNumber) || valueAsNumber === undefined || valueAsNumber < -1 ? DEFAULT_SETTINGS.extraWaitingTime : valueAsNumber;
             await this.plugin.saveSettings();
           })
       );

--- a/settings.ts
+++ b/settings.ts
@@ -26,7 +26,7 @@ export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
   shouldReplaceSelection: true,
   enhanceDefaultPaste: true,
   websiteBlacklist: "",
-  extraWaitingTime: 1000
+  extraWaitingTime: 150
 };
 
 export class AutoLinkTitleSettingTab extends PluginSettingTab {
@@ -89,7 +89,7 @@ export class AutoLinkTitleSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName("Extra Waiting Time")
-      .setDesc("Extra time to wait for the page to update the title. Increase this if you're getting a lot of URL or 'Site Unreachable' titles.")
+      .setDesc("Extra time to wait for the page to update the title in milliseconds. Increase this if you're getting a lot of URL or 'Site Unreachable' titles.")
       .addText((val) =>
         val
           .setValue(this.plugin.settings.extraWaitingTime?.toString())


### PR DESCRIPTION
Thanks for this plugin. It really saves a lot of time for my daily webpage clips.

When fetching titles of Wechat articles, it fails to get the correct one. After some investigation, I found the page title changs at least twice. The correct title can't be got just after the window did-finish-load event.

Since I couldn't find an opportunity to obtain the accurate title, I tried adding an extra waiting time to delay the title retrieval action until after the rendering was completed.

Hope this would helpful for anyone else occur to the same problem. 