### PR TITLE
Escape tag characters

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -210,9 +210,9 @@ export default class AutoLinkTitle extends Plugin {
   }
 
   escapeMarkdown(text: string): string {
-    var unescaped = text.replace(/\\(\*|_|`|~|\\|\[|\])/g, '$1'); // unescape any "backslashed" character
-    var escaped = unescaped.replace(/(\*|_|`|~|\\|\[|\])/g, '\\$1'); // escape *, _, `, ~, \, [, ]
-    return escaped;
+    var unescaped = text.replace(/\\(\*|_|`|~|\\|\[|\])/g, '$1') // unescape any "backslashed" character
+    var escaped = unescaped.replace(/(\*|_|`|<|>|~|\\|\[|\])/g, '\\$1') // escape *, _, `, ~, \, [, ], <, and >
+    return escaped
   }
 
   async fetchUrlTitle(url: string): Promise<string> {


### PR DESCRIPTION
Obsidian doesn't seem to like `<` or `>` (try with https://github.com/microsoft/TypeScript/issues/19944) so this PR adds escaping for those

![image](https://github.com/zolrath/obsidian-auto-link-title/assets/3200560/4b56a2c8-8546-46b8-b136-3f57793e296e)
