### PR TITLE
Fix: check `event.defaultPrevented` before handling events to avoid conflicts with other plugins

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -190,6 +190,8 @@ export default class AutoLinkTitle extends Plugin {
       return;
     }
 
+    if (dropEvent.defaultPrevented) return;
+
     // Only attempt fetch if online
     if (!navigator.onLine) return;
 

--- a/main.ts
+++ b/main.ts
@@ -147,6 +147,8 @@ export default class AutoLinkTitle extends Plugin {
       return;
     }
 
+    if (clipboard.defaultPrevented) return;
+
     // Only attempt fetch if online
     if (!navigator.onLine) return;
 


### PR DESCRIPTION
Hi, thank you for maintaining this plugin which is important for the community!

As stated in the developer documentation, a community plugin has to check `event.defaultPrevented` before handling `editor-paste` and `editor-drop` events to see if other plugins already handle the event.

- https://docs.obsidian.md/Reference/TypeScript+API/Workspace/on_12
- https://docs.obsidian.md/Reference/TypeScript+API/Workspace/on_13

So I added the two lines according to this. This change will fix conflicts with other plugins such as https://github.com/RyotaUshio/obsidian-advanced-external-links (sorry this is my plugin).
