### PR TITLE
New setting that allows not to override the selected text with fetched link

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -180,6 +180,12 @@ export default class AutoLinkTitle extends Plugin {
       return;
     }
 
+    // If url is pasted over selected text and setting is enabled, no need to fetch title, 
+    // just insert a link
+    if (selectedText && this.settings.shouldPreserveSelectionAsTitle) {
+      editor.replaceSelection(`[${selectedText}](${clipboardText})`);
+    }
+
     // At this point we're just pasting a link in a normal fashion, fetch its title.
     this.convertUrlToTitledLink(editor, clipboardText);
     return;

--- a/settings.ts
+++ b/settings.ts
@@ -28,6 +28,7 @@ export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
   imageRegex: /\.(gif|jpe?g|tiff?|png|webp|bmp|tga|psd|ai)$/i,
   shouldReplaceSelection: true,
   enhanceDefaultPaste: true,
+  shouldPreserveSelectionAsTitle: false,
   enhanceDropEvents: true,
   websiteBlacklist: "",
   maximumTitleLength: 0,

--- a/settings.ts
+++ b/settings.ts
@@ -8,6 +8,7 @@ export interface AutoLinkTitleSettings {
   linkLineRegex: RegExp;
   imageRegex: RegExp;
   shouldReplaceSelection: boolean;
+  shouldPreserveSelectionAsTitle: boolean;
   enhanceDefaultPaste: boolean;
   enhanceDropEvents: boolean;
   websiteBlacklist: string;
@@ -102,6 +103,20 @@ export class AutoLinkTitleSettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             console.log(value);
             this.plugin.settings.shouldReplaceSelection = value;
+            await this.plugin.saveSettings();
+          })
+      );
+    new Setting(containerEl)
+      .setName("Preserve selection as title")
+      .setDesc(
+        "Whether to prefer selected text as title over fetched title when pasting"
+      )
+      .addToggle((val) =>
+        val
+          .setValue(this.plugin.settings.shouldPreserveSelectionAsTitle)
+          .onChange(async (value) => {
+            console.log(value);
+            this.plugin.settings.shouldPreserveSelectionAsTitle = value;
             await this.plugin.saveSettings();
           })
       );


### PR DESCRIPTION
Based on https://github.com/zolrath/obsidian-auto-link-title/issues/50

Very simple PR that:

- adds a new setting
- in case if it's enabled, respects existing text selection as title