### PR TITLE
Add option for better paste IDs using invisible characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ main.js
 .DS_Store
 
 data.json
+/bun.lockb

--- a/main.ts
+++ b/main.ts
@@ -247,7 +247,7 @@ export default class AutoLinkTitle extends Plugin {
     }
 
     // Generate a unique id for find/replace operations for the title.
-    const pasteId = `Fetching Title#${this.createBlockHash()}`;
+    const pasteId = this.getPasteId();
 
     // Instantly paste so you don't wonder if paste is broken
     editor.replaceSelection(`[${pasteId}](${url})`);
@@ -308,6 +308,31 @@ export default class AutoLinkTitle extends Plugin {
   public getUrlFromLink(link: string): string {
     let urlRegex = new RegExp(DEFAULT_SETTINGS.linkRegex);
     return urlRegex.exec(link)[2];
+  }
+
+  private getPasteId(): string {
+    var base = "Fetching Title";
+    if (this.settings.useBetterPasteId) {
+      return this.getBetterPasteId(base);
+    } else {
+      return `${base}#${this.createBlockHash()}`;
+    }
+  }
+
+  private getBetterPasteId(base: string): string {
+    // After every character, add 0, 1 or 2 invisible characters
+    // so that to the user it looks just like the base string.
+    // The number of combinations is 3^14 = 4782969
+    let result = "";
+    var invisibleCharacter = "\u200B";
+    var maxInvisibleCharacters = 2;
+    for (var i = 0; i < base.length; i++) {
+      var count = Math.floor(
+        Math.random() * (maxInvisibleCharacters + 1)
+      );
+      result += base.charAt(i) + invisibleCharacter.repeat(count);
+    }
+    return result;
   }
 
   // Custom hashid by @shabegom

--- a/settings.ts
+++ b/settings.ts
@@ -13,6 +13,7 @@ export interface AutoLinkTitleSettings {
   websiteBlacklist: string;
   maximumTitleLength: number;
   useNewScraper: boolean;
+  useBetterPasteId: boolean;
 }
 
 export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
@@ -31,6 +32,7 @@ export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
   websiteBlacklist: "",
   maximumTitleLength: 0,
   useNewScraper: false,
+  useBetterPasteId: false,
 };
 
 export class AutoLinkTitleSettingTab extends PluginSettingTab {
@@ -132,6 +134,21 @@ export class AutoLinkTitleSettingTab extends PluginSettingTab {
           .onChange(async (value) => {
             console.log(value);
             this.plugin.settings.useNewScraper = value;
+            await this.plugin.saveSettings();
+          })
+    );
+    
+    new Setting(containerEl)
+      .setName("Use Better Fetching Placeholder")
+      .setDesc(
+        "Use a more readable placeholder when fetching the title of a link."
+      )
+      .addToggle((val) =>
+        val
+          .setValue(this.plugin.settings.useBetterPasteId)
+          .onChange(async (value) => {
+            console.log(value);
+            this.plugin.settings.useBetterPasteId = value;
             await this.plugin.saveSettings();
           })
       );


### PR DESCRIPTION
<img width="851" alt="Bildschirmfoto 2024-08-14 um 15 32 04" src="https://github.com/user-attachments/assets/073024a8-7472-4bf3-9e1f-21f65c93d657">

Add a new option called "Use Better Fetching Placeholder" that when activated will generate unique paste IDs by placing invisible characters in random places in the "Fetching Title" string so that it looks a bit nicer.

If activated, this new generation method might cause some problems with some spellchecks. 