### PR TITLE
Add notice message when offline

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,6 @@
 import { CheckIf } from "checkif";
 import { EditorExtensions } from "editor-enhancements";
-import { Editor, Plugin } from "obsidian";
+import { Editor, Plugin, Notice } from "obsidian";
 import getPageTitle from "scraper";
 import getElectronPageTitle from "electron-scraper";
 import {
@@ -80,7 +80,6 @@ export default class AutoLinkTitle extends Plugin {
 
   addTitleToLink(editor: Editor): void {
     // Only attempt fetch if online
-    if (!navigator.onLine) return;
 
     let selectedText = (EditorExtensions.getSelectedText(editor) || "").trim();
 
@@ -88,6 +87,12 @@ export default class AutoLinkTitle extends Plugin {
     if (CheckIf.isUrl(selectedText)) {
       this.convertUrlToTitledLink(editor, selectedText);
     }
+
+    if (!navigator.onLine) {
+      new Notice("No internet connection. Cannot fetch title.");
+      return;
+    }
+
     // If the cursor is on the URL part of a markdown link, fetch title and replace existing link title
     else if (CheckIf.isLinkedUrl(selectedText)) {
       const link = this.getUrlFromLink(selectedText);
@@ -109,6 +114,7 @@ export default class AutoLinkTitle extends Plugin {
     // Only attempt fetch if online
     if (!navigator.onLine) {
       editor.replaceSelection(clipboardText);
+      new Notice("No internet connection. Cannot fetch title.");
       return;
     }
 
@@ -153,9 +159,6 @@ export default class AutoLinkTitle extends Plugin {
 
     if (clipboard.defaultPrevented) return;
 
-    // Only attempt fetch if online
-    if (!navigator.onLine) return;
-
     let clipboardText = clipboard.clipboardData.getData("text/plain");
     if (clipboardText === null || clipboardText === "") return;
 
@@ -163,6 +166,12 @@ export default class AutoLinkTitle extends Plugin {
     // Similarly, image urls don't have a meaningful <title> attribute so downloading it
     // to fetch the title is a waste of bandwidth.
     if (!CheckIf.isUrl(clipboardText) || CheckIf.isImage(clipboardText)) {
+      return;
+    }
+
+    // Only attempt fetch if online
+    if (!navigator.onLine) {
+      new Notice("No internet connection. Cannot fetch title.");
       return;
     }
 
@@ -198,9 +207,6 @@ export default class AutoLinkTitle extends Plugin {
 
     if (dropEvent.defaultPrevented) return;
 
-    // Only attempt fetch if online
-    if (!navigator.onLine) return;
-
     let dropText = dropEvent.dataTransfer.getData("text/plain");
     if (dropText === null || dropText === "") return;
 
@@ -208,6 +214,11 @@ export default class AutoLinkTitle extends Plugin {
     // Similarly, image urls don't have a meaningful <title> attribute so downloading it
     // to fetch the title is a waste of bandwidth.
     if (!CheckIf.isUrl(dropText) || CheckIf.isImage(dropText)) {
+      return;
+    }
+    // Only attempt fetch if online
+    if (!navigator.onLine) {
+      new Notice("No internet connection. Cannot fetch title.");
       return;
     }
 
@@ -375,9 +386,7 @@ export default class AutoLinkTitle extends Plugin {
     var invisibleCharacter = "\u200B";
     var maxInvisibleCharacters = 2;
     for (var i = 0; i < base.length; i++) {
-      var count = Math.floor(
-        Math.random() * (maxInvisibleCharacters + 1)
-      );
+      var count = Math.floor(Math.random() * (maxInvisibleCharacters + 1));
       result += base.charAt(i) + invisibleCharacter.repeat(count);
     }
     return result;

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,6 @@
 import { CheckIf } from "checkif";
 import { EditorExtensions } from "editor-enhancements";
-import { Editor, Plugin, Notice } from "obsidian";
+import { Editor, Plugin } from "obsidian";
 import getPageTitle from "scraper";
 import getElectronPageTitle from "electron-scraper";
 import {
@@ -80,6 +80,7 @@ export default class AutoLinkTitle extends Plugin {
 
   addTitleToLink(editor: Editor): void {
     // Only attempt fetch if online
+    if (!navigator.onLine) return;
 
     let selectedText = (EditorExtensions.getSelectedText(editor) || "").trim();
 
@@ -87,12 +88,6 @@ export default class AutoLinkTitle extends Plugin {
     if (CheckIf.isUrl(selectedText)) {
       this.convertUrlToTitledLink(editor, selectedText);
     }
-
-    if (!navigator.onLine) {
-      new Notice("No internet connection. Cannot fetch title.");
-      return;
-    }
-
     // If the cursor is on the URL part of a markdown link, fetch title and replace existing link title
     else if (CheckIf.isLinkedUrl(selectedText)) {
       const link = this.getUrlFromLink(selectedText);
@@ -114,7 +109,6 @@ export default class AutoLinkTitle extends Plugin {
     // Only attempt fetch if online
     if (!navigator.onLine) {
       editor.replaceSelection(clipboardText);
-      new Notice("No internet connection. Cannot fetch title.");
       return;
     }
 
@@ -159,6 +153,9 @@ export default class AutoLinkTitle extends Plugin {
 
     if (clipboard.defaultPrevented) return;
 
+    // Only attempt fetch if online
+    if (!navigator.onLine) return;
+
     let clipboardText = clipboard.clipboardData.getData("text/plain");
     if (clipboardText === null || clipboardText === "") return;
 
@@ -166,12 +163,6 @@ export default class AutoLinkTitle extends Plugin {
     // Similarly, image urls don't have a meaningful <title> attribute so downloading it
     // to fetch the title is a waste of bandwidth.
     if (!CheckIf.isUrl(clipboardText) || CheckIf.isImage(clipboardText)) {
-      return;
-    }
-
-    // Only attempt fetch if online
-    if (!navigator.onLine) {
-      new Notice("No internet connection. Cannot fetch title.");
       return;
     }
 
@@ -207,6 +198,9 @@ export default class AutoLinkTitle extends Plugin {
 
     if (dropEvent.defaultPrevented) return;
 
+    // Only attempt fetch if online
+    if (!navigator.onLine) return;
+
     let dropText = dropEvent.dataTransfer.getData("text/plain");
     if (dropText === null || dropText === "") return;
 
@@ -214,11 +208,6 @@ export default class AutoLinkTitle extends Plugin {
     // Similarly, image urls don't have a meaningful <title> attribute so downloading it
     // to fetch the title is a waste of bandwidth.
     if (!CheckIf.isUrl(dropText) || CheckIf.isImage(dropText)) {
-      return;
-    }
-    // Only attempt fetch if online
-    if (!navigator.onLine) {
-      new Notice("No internet connection. Cannot fetch title.");
       return;
     }
 
@@ -386,7 +375,9 @@ export default class AutoLinkTitle extends Plugin {
     var invisibleCharacter = "\u200B";
     var maxInvisibleCharacters = 2;
     for (var i = 0; i < base.length; i++) {
-      var count = Math.floor(Math.random() * (maxInvisibleCharacters + 1));
+      var count = Math.floor(
+        Math.random() * (maxInvisibleCharacters + 1)
+      );
       result += base.charAt(i) + invisibleCharacter.repeat(count);
     }
     return result;

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,6 @@
 import { CheckIf } from "checkif";
 import { EditorExtensions } from "editor-enhancements";
-import { Editor, Plugin } from "obsidian";
+import { Editor, Plugin, Notice } from "obsidian";
 import getPageTitle from "scraper";
 import getElectronPageTitle from "electron-scraper";
 import {
@@ -80,7 +80,6 @@ export default class AutoLinkTitle extends Plugin {
 
   addTitleToLink(editor: Editor): void {
     // Only attempt fetch if online
-    if (!navigator.onLine) return;
 
     let selectedText = (EditorExtensions.getSelectedText(editor) || "").trim();
 
@@ -88,6 +87,12 @@ export default class AutoLinkTitle extends Plugin {
     if (CheckIf.isUrl(selectedText)) {
       this.convertUrlToTitledLink(editor, selectedText);
     }
+
+    if (!navigator.onLine) {
+      new Notice("No internet connection. Cannot fetch title.");
+      return;
+    }
+
     // If the cursor is on the URL part of a markdown link, fetch title and replace existing link title
     else if (CheckIf.isLinkedUrl(selectedText)) {
       const link = this.getUrlFromLink(selectedText);
@@ -109,6 +114,7 @@ export default class AutoLinkTitle extends Plugin {
     // Only attempt fetch if online
     if (!navigator.onLine) {
       editor.replaceSelection(clipboardText);
+      new Notice("No internet connection. Cannot fetch title.");
       return;
     }
 
@@ -153,9 +159,6 @@ export default class AutoLinkTitle extends Plugin {
 
     if (clipboard.defaultPrevented) return;
 
-    // Only attempt fetch if online
-    if (!navigator.onLine) return;
-
     let clipboardText = clipboard.clipboardData.getData("text/plain");
     if (clipboardText === null || clipboardText === "") return;
 
@@ -163,6 +166,12 @@ export default class AutoLinkTitle extends Plugin {
     // Similarly, image urls don't have a meaningful <title> attribute so downloading it
     // to fetch the title is a waste of bandwidth.
     if (!CheckIf.isUrl(clipboardText) || CheckIf.isImage(clipboardText)) {
+      return;
+    }
+
+    // Only attempt fetch if online
+    if (!navigator.onLine) {
+      new Notice("No internet connection. Cannot fetch title.");
       return;
     }
 
@@ -198,9 +207,6 @@ export default class AutoLinkTitle extends Plugin {
 
     if (dropEvent.defaultPrevented) return;
 
-    // Only attempt fetch if online
-    if (!navigator.onLine) return;
-
     let dropText = dropEvent.dataTransfer.getData("text/plain");
     if (dropText === null || dropText === "") return;
 
@@ -208,6 +214,11 @@ export default class AutoLinkTitle extends Plugin {
     // Similarly, image urls don't have a meaningful <title> attribute so downloading it
     // to fetch the title is a waste of bandwidth.
     if (!CheckIf.isUrl(dropText) || CheckIf.isImage(dropText)) {
+      return;
+    }
+    // Only attempt fetch if online
+    if (!navigator.onLine) {
+      new Notice("No internet connection. Cannot fetch title.");
       return;
     }
 


### PR DESCRIPTION
## Description
Sometimes, when I paste a URL using this plugin, it just pastes the raw url link without fetching the title (ex: `https://google.com`) and I found out that  it's coming from `navigator.onLine` property.

This is not really this plugin's bug but it would be nice to inform user the reason why this plugin in not working as usual.

I added `obsidian.Notice` for `navigation.onLine` guard and moved the if-block after  `CheckIf.isUrl`, since you don't really need to check the internet status if you're not going to fetch the title.
