### PR TITLE
feat: Add option to select placeholder for Blacklisted URL

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -7,6 +7,7 @@ import {
   AutoLinkTitleSettingTab,
   AutoLinkTitleSettings,
   DEFAULT_SETTINGS,
+  BlacklistTitlePlaceholder,
 } from "./settings";
 
 interface PasteFunction {
@@ -258,8 +259,12 @@ export default class AutoLinkTitle extends Plugin {
 
   async convertUrlToTitledLink(editor: Editor, url: string): Promise<void> {
     if (await this.isBlacklisted(url)) {
-      let domain = new URL(url).hostname;
-      editor.replaceSelection(`[${domain}](${url})`);
+      const placeholder =
+        this.settings.blacklistTitlePlaceholder ===
+        BlacklistTitlePlaceholder.DOMAIN
+          ? new URL(url).hostname
+          : url;
+      editor.replaceSelection(`[${placeholder}](${url})`);
       return;
     }
 

--- a/settings.ts
+++ b/settings.ts
@@ -12,10 +12,16 @@ export interface AutoLinkTitleSettings {
   enhanceDefaultPaste: boolean;
   enhanceDropEvents: boolean;
   websiteBlacklist: string;
+  blacklistTitlePlaceholder: BlacklistTitlePlaceholder;
   maximumTitleLength: number;
   useNewScraper: boolean;
   linkPreviewApiKey: string;
   useBetterPasteId: boolean;
+}
+
+export enum BlacklistTitlePlaceholder {
+  DOMAIN = "DOMAIN",
+  URL = "URL",
 }
 
 export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
@@ -32,6 +38,7 @@ export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
   shouldPreserveSelectionAsTitle: false,
   enhanceDropEvents: true,
   websiteBlacklist: "",
+  blacklistTitlePlaceholder: BlacklistTitlePlaceholder.DOMAIN,
   maximumTitleLength: 0,
   useNewScraper: false,
   linkPreviewApiKey: "",
@@ -126,6 +133,22 @@ export class AutoLinkTitleSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Blacklist Title Placeholder")
+      .setDesc(
+        "Choose how to display the title for a URL that has been blacklisted"
+      )
+      .addDropdown((dropdown) => {
+        dropdown.addOption("DOMAIN", "Domain");
+        dropdown.addOption("URL", "URL");
+        dropdown.setValue(this.plugin.settings.blacklistTitlePlaceholder);
+        dropdown.onChange(async (value) => {
+          this.plugin.settings.blacklistTitlePlaceholder =
+            value as BlacklistTitlePlaceholder;
+          await this.plugin.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
       .setName("Use New Scraper")
       .setDesc(
         "Use experimental new scraper, seems to work well on desktop but not mobile."
@@ -138,8 +161,8 @@ export class AutoLinkTitleSettingTab extends PluginSettingTab {
             this.plugin.settings.useNewScraper = value;
             await this.plugin.saveSettings();
           })
-    );
-    
+      );
+
     new Setting(containerEl)
       .setName("Use Better Fetching Placeholder")
       .setDesc(


### PR DESCRIPTION
User can choose what can be Title placeholder for a URL that has been blacklisted.

Scenario:
- User has blacklisted www.reddit.com
- And then pasted the url `https://www.reddit.com/r/Damnthatsinteresting/comments/1m85nur/footage_of_the_2004_indian_ocean_tsunami_which/`
- If user has selected "Domain" option
  - Title will be `www.reddit.com`
- If user has selected "URL" option
  - Title will be `https://www.reddit.com/r/Damnthatsinteresting/comments/1m85nur/footage_of_the_2004_indian_ocean_tsunami_which/`