### PR TITLE
fix: paste blacklisted URLs raw instead of wrapping as markdown link

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -258,8 +258,7 @@ export default class AutoLinkTitle extends Plugin {
 
   async convertUrlToTitledLink(editor: Editor, url: string): Promise<void> {
     if (await this.isBlacklisted(url)) {
-      let domain = new URL(url).hostname;
-      editor.replaceSelection(`[${domain}](${url})`);
+      editor.replaceSelection(url);
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes #159.

When a URL matches the website blacklist, it is now pasted as-is instead of being wrapped as `[domain](url)`. The previous behavior defeated the purpose of the blacklist for users who integrate with other plugins that expect a bare URL (e.g. the Thumbnails plugin for YouTube, as described in the linked issue).

## What I tested

- Added `youtube.com` to the Website Blacklist
- Pasted a YouTube URL — confirmed it appears as raw text, not wrapped as `[youtube.com](https://...)`
- Pasted a non-blacklisted URL — confirmed normal title-fetching still works