### PR TITLE
feat: skip URL enhancement inside code blocks

### DIFF
--- a/checkif.ts
+++ b/checkif.ts
@@ -1,7 +1,56 @@
 import { Editor } from "obsidian";
+import { syntaxTree, ensureSyntaxTree } from "@codemirror/language";
 import { DEFAULT_SETTINGS } from 'settings';
 
 export class CheckIf {
+  public static isInsideCodeBlock(editor: Editor): boolean {
+    // @ts-expect-error - cm is an undocumented but stable EditorView reference
+    const view = editor.cm;
+    if (!view) return false;
+    const pos = view.state.selection.main.head;
+    const tree =
+      ensureSyntaxTree(view.state, view.state.doc.length, 50) ?? syntaxTree(view.state);
+    let found = false;
+    tree.iterate({
+      from: pos,
+      to: pos,
+      enter(n) {
+        if (found) return false;
+        // Obsidian's CM6 markdown parse produces node type names that are
+        // underscore-joined HyperMD token classes (e.g. "HyperMD-codeblock_hmd-codeblock",
+        // "formatting_formatting-code_inline-code"). We also tolerate the bare Lezer
+        // markdown node names ("FencedCode", "InlineCode", ...) in case the token-class
+        // layer is absent in some views.
+        const name = n.type.name;
+        if (
+          name.includes("codeblock") ||
+          name.includes("code-block") ||
+          name.includes("inline-code") ||
+          name === "FencedCode" ||
+          name === "CodeBlock" ||
+          name === "InlineCode" ||
+          name === "CodeText"
+        ) {
+          found = true;
+        }
+      },
+    });
+    if (found) return true;
+
+    // Fallback: an unclosed fenced block has no closing ``` yet, so the parser
+    // hasn't committed it to a FencedCode node. Count fence markers on lines
+    // strictly above the cursor line — an odd count means we're inside an open fence.
+    const { doc } = view.state;
+    const cursorLine = doc.lineAt(pos);
+    let fenceMarkers = 0;
+    for (let n = 1; n < cursorLine.number; n++) {
+      if (/^\s{0,3}(`{3,}|~{3,})/.test(doc.line(n).text)) {
+        fenceMarkers++;
+      }
+    }
+    return fenceMarkers % 2 === 1;
+  }
+
   public static isMarkdownLinkAlready(editor: Editor): boolean {
     let cursor = editor.getCursor();
 

--- a/main.ts
+++ b/main.ts
@@ -136,6 +136,11 @@ export default class AutoLinkTitle extends Plugin {
       return;
     }
 
+    if (!this.settings.enhanceInsideCodeBlocks && CheckIf.isInsideCodeBlock(editor)) {
+      editor.replaceSelection(clipboardText);
+      return;
+    }
+
     // If url is pasted over selected text and setting is enabled, no need to fetch title,
     // just insert a link
     let selectedText = (EditorExtensions.getSelectedText(editor) || "").trim();
@@ -166,6 +171,12 @@ export default class AutoLinkTitle extends Plugin {
     // Similarly, image urls don't have a meaningful <title> attribute so downloading it
     // to fetch the title is a waste of bandwidth.
     if (!CheckIf.isUrl(clipboardText) || CheckIf.isImage(clipboardText)) {
+      return;
+    }
+
+    // If the cursor is inside a code block, let the default paste handler
+    // insert the raw URL instead of wrapping it in a markdown link.
+    if (!this.settings.enhanceInsideCodeBlocks && CheckIf.isInsideCodeBlock(editor)) {
       return;
     }
 
@@ -216,6 +227,13 @@ export default class AutoLinkTitle extends Plugin {
     if (!CheckIf.isUrl(dropText) || CheckIf.isImage(dropText)) {
       return;
     }
+
+    // If the cursor is inside a code block, let the default drop handler
+    // insert the raw URL instead of wrapping it in a markdown link.
+    if (!this.settings.enhanceInsideCodeBlocks && CheckIf.isInsideCodeBlock(editor)) {
+      return;
+    }
+
     // Only attempt fetch if online
     if (!navigator.onLine) {
       new Notice("No internet connection. Cannot fetch title.");

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.5.5",
       "license": "MIT",
       "devDependencies": {
+        "@codemirror/language": "^6.12.3",
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/plugin-typescript": "^8.2.1",
@@ -19,24 +20,77 @@
         "typescript": "^5.2.2"
       }
     },
-    "node_modules/@codemirror/state": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.3.1.tgz",
-      "integrity": "sha512-88e4HhMtKJyw6fKprGaN/yZfiaoGYOi2nM45YCUC6R/kex9sxFWBDGatS1vk4lMgnWmdIIB9tk8Gj1LmL8YfvA==",
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
       "dev": true,
-      "peer": true
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.21.3.tgz",
-      "integrity": "sha512-8l1aSQ6MygzL4Nx7GVYhucSXvW4jQd0F6Zm3v9Dg+6nZEfwzJVqi4C2zHfDljID+73gsQrWp9TgHc81xU15O4A==",
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
+      "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "@codemirror/state": "^6.1.4",
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "18.0.0",
@@ -198,6 +252,13 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -441,8 +502,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
       "integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -479,8 +539,7 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@codemirror/language": "^6.12.3",
     "@rollup/plugin-commonjs": "^18.0.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-typescript": "^8.2.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,7 @@ export default {
     exports: 'default',
     banner,
   },
-  external: ['obsidian'],
+  external: ['obsidian', '@codemirror/language', '@codemirror/view', '@codemirror/state'],
   plugins: [
     typescript(),
     nodeResolve({ browser: true }),

--- a/settings.ts
+++ b/settings.ts
@@ -84,6 +84,20 @@ export class AutoLinkTitleSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName("Enhance inside code blocks")
+      .setDesc(
+        "When disabled, pasting a URL inside a fenced or inline code block leaves it as raw text instead of wrapping it in a markdown link."
+      )
+      .addToggle((val) =>
+        val
+          .setValue(this.plugin.settings.enhanceInsideCodeBlocks)
+          .onChange(async (value) => {
+            this.plugin.settings.enhanceInsideCodeBlocks = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
       .setName("Maximum title length")
       .setDesc("Set the maximum length of the title. Set to 0 to disable.")
       .addText((val) =>
@@ -123,20 +137,6 @@ export class AutoLinkTitleSettingTab extends PluginSettingTab {
           .setPlaceholder("localhost, tiktok.com")
           .onChange(async (value) => {
             this.plugin.settings.websiteBlacklist = value;
-            await this.plugin.saveSettings();
-          })
-      );
-
-    new Setting(containerEl)
-      .setName("Enhance inside code blocks")
-      .setDesc(
-        "When disabled, pasting a URL inside a fenced or inline code block leaves it as raw text instead of wrapping it in a markdown link."
-      )
-      .addToggle((val) =>
-        val
-          .setValue(this.plugin.settings.enhanceInsideCodeBlocks)
-          .onChange(async (value) => {
-            this.plugin.settings.enhanceInsideCodeBlocks = value;
             await this.plugin.saveSettings();
           })
       );

--- a/settings.ts
+++ b/settings.ts
@@ -16,6 +16,7 @@ export interface AutoLinkTitleSettings {
   useNewScraper: boolean;
   linkPreviewApiKey: string;
   useBetterPasteId: boolean;
+  enhanceInsideCodeBlocks: boolean;
 }
 
 export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
@@ -36,6 +37,7 @@ export const DEFAULT_SETTINGS: AutoLinkTitleSettings = {
   useNewScraper: false,
   linkPreviewApiKey: "",
   useBetterPasteId: false,
+  enhanceInsideCodeBlocks: false,
 };
 
 export class AutoLinkTitleSettingTab extends PluginSettingTab {
@@ -121,6 +123,20 @@ export class AutoLinkTitleSettingTab extends PluginSettingTab {
           .setPlaceholder("localhost, tiktok.com")
           .onChange(async (value) => {
             this.plugin.settings.websiteBlacklist = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Enhance inside code blocks")
+      .setDesc(
+        "When disabled, pasting a URL inside a fenced or inline code block leaves it as raw text instead of wrapping it in a markdown link."
+      )
+      .addToggle((val) =>
+        val
+          .setValue(this.plugin.settings.enhanceInsideCodeBlocks)
+          .onChange(async (value) => {
+            this.plugin.settings.enhanceInsideCodeBlocks = value;
             await this.plugin.saveSettings();
           })
       );


### PR DESCRIPTION
Closes #36, closes #58, closes #153, closes #162.

## Summary

Pasting or dropping a URL inside a fenced code block or inline code currently wraps it in a markdown link, which is almost never what you want, since the link syntax becomes literal text inside the code. This adds a new **"Enhance inside code blocks"** setting that gates the behavior.

## Approach

Detection uses the CodeMirror 6 Lezer syntax tree via `syntaxTree()` and `ensureSyntaxTree()`, and checks whether any node covering the cursor position is code. Because Obsidian layers HyperMD token classes on top of the Lezer markdown parser, the check matches both the HyperMD class names (`HyperMD-codeblock`, `hmd-codeblock`, `inline-code`) and the bare Lezer names (`FencedCode`, `InlineCode`, and so on). A simple fence-counting fallback handles the case where the user is inside an unclosed fenced block that the parser has not committed to a `FencedCode` node yet.

`@codemirror/language` is added as a devDep and rollup external. It is already a transitive dep of `obsidian`, so Obsidian provides it at runtime.

## Open question: should this be a setting at all?

This PR adds a setting that defaults to **off**, which changes the current behavior (URLs inside code no longer expand). Three reasonable options, happy with any of them:

1. Keep as is: setting defaults to **off**, new skip behavior becomes the default.
2. Setting defaults to **on**, preserving today's behavior, users opt in to skip.
3. Drop the setting entirely and make skipping in code blocks the unconditional new default. Given that wrapping URLs inside code blocks is essentially never desired (every linked issue wants this disabled), a setting may be unneeded complexity. This would simplify the code and the settings UI.

Let me know which you prefer and I will adjust.

## What I tested

- Pasted a URL in a normal paragraph: still expands with title
- Pasted a URL inside a closed ` ``` ` fenced code block: stays raw
- Pasted a URL inside inline `` ` `` code: stays raw
- Pasted a URL after a single `` ` `` with no closing backtick: stays raw
- Pasted a URL inside an unclosed fenced block (` ``` ` on its own line, newline, paste): stays raw (covered by the fence-counting fallback)
- Toggled "Enhance inside code blocks" on: all the above expand again
- Verified on both desktop and iOS (Obsidian mobile)