### PR TITLE
fix: don't classify bare domains with image-like TLDs as images

### DIFF
--- a/checkif.ts
+++ b/checkif.ts
@@ -33,8 +33,15 @@ export class CheckIf {
   }
 
   public static isImage(text: string): boolean {
+    // Match the extension only against the URL's pathname, not the full URL.
+    // Otherwise a bare domain on an image-like TLD (e.g. https://openclaw.ai
+    // for the ".ai" Adobe Illustrator extension) is misclassified as an image.
     let imageRegex = new RegExp(DEFAULT_SETTINGS.imageRegex);
-    return imageRegex.test(text);
+    try {
+      return imageRegex.test(new URL(text).pathname);
+    } catch {
+      return imageRegex.test(text);
+    }
   }
 
   public static isLinkedUrl(text: string): boolean {


### PR DESCRIPTION
Closes #172.

## Summary

The image detection regex includes `ai` for Adobe Illustrator files. Because it was tested against the full URL string, any bare domain on the `.ai` TLD (https://openclaw.ai, https://grok.ai, https://mistral.ai, and similar) matched the regex and was treated as an image. The paste handler skips images to save bandwidth, so these URLs silently fell through to the default paste and never had their titles fetched, which is what #172 reports as "the plugin doesn't work with this link".

## Approach

Test the regex against the URL's `pathname` instead of the full URL. A bare domain has pathname `/`, which never matches the extension regex. A URL like https://openclaw.ai/logo.ai still matches because the extension appears in the path. If URL parsing fails for any reason the previous behavior (testing the full string) is used as a fallback.

Not touching the `imageRegex` itself, since `.ai` files are legitimate Illustrator documents that should continue to be recognized when they appear in a path.

## What I tested

- Pasted `https://openclaw.ai`: title now fetched correctly
- Pasted `https://www.w3.org/Graphics/PNG/alphatest.png`: recognized as image, raw paste, as before
- Pasted `https://openclaw.ai/logo.ai`: recognized as image, raw paste (same TLD, but path ends in `.ai`)
- Pasted a regular URL without an image extension: still expands with title